### PR TITLE
added utf-8 resonvling encoding issue in f.read

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ PORT_NUMBER = 8001
 
 trees_api_url = "https://api.ecosia.org/v1/trees/count"
 
-with open("./templates/treeCounter.html", "r", encoding='utf-8') as f:
+with open("./templates/treeCounter.html", "r", encoding="utf-8") as f:
     html_string = f.read()
 html_template = Template(html_string)
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ PORT_NUMBER = 8001
 
 trees_api_url = "https://api.ecosia.org/v1/trees/count"
 
-with open("./templates/treeCounter.html", "r") as f:
+with open("./templates/treeCounter.html", "r", encoding='utf-8') as f:
     html_string = f.read()
 html_template = Template(html_string)
 


### PR DESCRIPTION
Hi,

thanks for the tutorial!
I propose adding this cause I had the following issue when running main (with python 3.10 and installing poetry):
```Traceback (most recent call last):
  File "C:\Users\AX-St\DataTalksClub\Prometheus tutorial\pycon22-prometheus-workshop\app\main.py", line 15, in <module>
    html_string = f.read()
  File "C:\Users\AX-St\AppData\Local\Programs\Python\Python310\lib\encodings\cp1253.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9f in position 1420: character maps to <undefined> 
```
what do you think?
